### PR TITLE
feat: add `index` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Rekor Sidekick uses a single configuration file with three important sections:
 
 - `server` to point to the Rekor server you want to monitor,
 - `policies` to specify which entries you want to alert on, and,
+- `index` to specify a starting Rekor index (default `-1` will tail the Rekor log)
 - `outputs` to specify where you want to send your alerts
 
 The `etc` directory contains sample configurations.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -22,7 +22,7 @@ type impl struct {
 func New(c Config) (Agent, error) {
 	log := newLogger(c)
 
-	rc, err := rekor.NewClient(c.Server)
+	rc, err := rekor.NewClient(c.Server, c.Index)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/config.go
+++ b/agent/config.go
@@ -5,6 +5,7 @@ import "github.com/nsmith5/rekor-sidekick/policy"
 // Config is the data required to configure an agent
 type Config struct {
 	Server   string                            `yaml:"server"`
+	Index    int                               `yaml:"index" default:"-1"`
 	Policies []policy.Policy                   `yaml:"policies"`
 	Outputs  map[string]map[string]interface{} `yaml:"outputs"`
 	Logging  struct {

--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -1,4 +1,5 @@
-server: https://rekor.sigstore.dev
+# Omit or set to -1 to tail the Rekor log
+# index: 0
 
 logging:
   level: trace

--- a/rekor/client.go
+++ b/rekor/client.go
@@ -19,13 +19,15 @@ type impl struct {
 
 // NewClient returns a Rekor client or fails if the baseURL
 // is misconfigured.
-func NewClient(baseURL string) (Client, error) {
+func NewClient(baseURL string, index int) (Client, error) {
 	rc := impl{
 		baseURL:      baseURL,
 		currentIndex: 0,
 		Client:       new(http.Client),
 	}
 
+	// No starting index provided by the config
+	if index == -1 {
 	// Grab the latest signed tree state and use the tree size as a starting
 	// point to start iterating log entries. Its not the very tip of the log,
 	// but its close enough for us.
@@ -36,6 +38,9 @@ func NewClient(baseURL string) (Client, error) {
 		return nil, fmt.Errorf("failed to get initial tree state. Is rekor server configured correctly? Failured caused by %w", err)
 	}
 	rc.currentIndex = state.TreeSize
+	} else {
+		rc.currentIndex = uint(index)
+	}
 
 	return &rc, nil
 }

--- a/rekor/client_test.go
+++ b/rekor/client_test.go
@@ -39,7 +39,7 @@ func TestGetLogEntry(t *testing.T) {
 		`/api/v1/log/entries`: `testdata/rekor-api-log-entry.json`,
 	})
 
-	rc, err := NewClient(ts.URL)
+	rc, err := NewClient(ts.URL, -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestGetTreeState(t *testing.T) {
 		`/api/v1/log`: `testdata/rekor-api-log.json`,
 	})
 
-	rc, err := NewClient(ts.URL)
+	rc, err := NewClient(ts.URL, -1)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
By default `rekor-sidekick` follows the tail of the Rekor log. This probably makes sense in most use-cases, but if we're mirroring attestations out to a searchable database, or testing on a self-hosted Rekor instance (which is receiving less traffic) it's helpful to be able to replay the whole Rekor instance or replay it from a certain point.

The new `index` configuration, when set to `-1` (default) just follows the Rekor instance like before, but if you set it to a value >=0, then it replays rekor from that index.

- [X] Each commit is signed off (using the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)). You can ensure this is the case by adding the -s flag when you commit code.
- [X] All tests are passing (ensure this locally before pushing code with go test ./...)